### PR TITLE
fix: unuse log fatal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,5 @@ services:
     volumes: 
       - .:/go/src/work
     ports:
-      - "8080:8080"
+      - "8081:8080"
     restart: always

--- a/main.go
+++ b/main.go
@@ -62,9 +62,9 @@ func switchbot_post(deviceId string, command *RequestBody) {
 	res, err := client.Do(req)
 	if err != nil {
 		log.Println(err)
+	} else {
+		defer res.Body.Close()
 	}
-
-	defer res.Body.Close()
 
 	body, _ := ioutil.ReadAll(res.Body)
 	fmt.Println(string(body))

--- a/main.go
+++ b/main.go
@@ -62,9 +62,10 @@ func switchbot_post(deviceId string, command *RequestBody) {
 	res, err := client.Do(req)
 	if err != nil {
 		log.Println(err)
-	} else {
-		defer res.Body.Close()
+		return
 	}
+
+	defer res.Body.Close()
 
 	body, _ := ioutil.ReadAll(res.Body)
 	fmt.Println(string(body))

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func switchbot_post(deviceId string, command *RequestBody) {
 
 	res, err := client.Do(req)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
 	defer res.Body.Close()


### PR DESCRIPTION
`log.Fatal`を使うとプログラムが終了してしまうので、使わないようにする